### PR TITLE
Fix entry of signing certificate password

### DIFF
--- a/ProfileCreator/ProfileCreator/Profile/ProfileController.swift
+++ b/ProfileCreator/ProfileCreator/Profile/ProfileController.swift
@@ -506,13 +506,29 @@ class ProfileController: NSDocumentController {
         savePanel.beginSheetModal(for: window) { response in
             if response != .OK { return }
             if let profileURL = savePanel.url {
-                do {
-                    try ProfileExport(exportSettings: exportSettings).export(profile: profile, profileURL: profileURL)
-                } catch {
-                    Log.shared.error(message: "Failed to export profile with identifier: \(profile.identifier) to path: \(profileURL.path) with error: \(error.localizedDescription)", category: String(describing: self))
-                    self.showAlertExport(error: error, window: window)
-                }
+                let settings: [String: Any] = [
+                    "profile": profile,
+                    "settings": exportSettings,
+                    "profileURL": profileURL,
+                    "window": window
+                ]
+
+                self.perform(#selector(self.performExport(settings:)), on: Thread.main, with: settings, waitUntilDone: false)
             } else { Log.shared.error(message: "Failed to get the selected save path from the save panel for profile with identifier: \(profile.identifier)", category: String(describing: self)) }
+        }
+    }
+
+    @objc private func performExport(settings: [String: Any]) {
+        let profile = settings["profile"] as! Profile
+        let exportSettings = settings["settings"] as! ProfileSettings
+        let profileURL = settings["profileURL"] as! URL
+        let window = settings["window"] as! NSWindow
+
+        do {
+            try ProfileExport(exportSettings: exportSettings).export(profile: profile, profileURL: profileURL)
+        } catch {
+            Log.shared.error(message: "Failed to export profile with identifier: \(profile.identifier) to path: \(profileURL.path) with error: \(error.localizedDescription)", category: String(describing: self))
+            self.showAlertExport(error: error, window: window)
         }
     }
 

--- a/ProfileCreator/ProfileCreator/Profile/ProfileController.swift
+++ b/ProfileCreator/ProfileCreator/Profile/ProfileController.swift
@@ -513,6 +513,8 @@ class ProfileController: NSDocumentController {
                     "window": window
                 ]
 
+                // Run the export proccess asynchronously, to give the sheet time
+                // to be dismissed before we show the modal password dialog.
                 self.perform(#selector(self.performExport(settings:)), on: Thread.main, with: settings, waitUntilDone: false)
             } else { Log.shared.error(message: "Failed to get the selected save path from the save panel for profile with identifier: \(profile.identifier)", category: String(describing: self)) }
         }


### PR DESCRIPTION
The bug appeared to be that the Save sheet conflicted with the Security framework's password dialog, causing the inputs to be lost. I fixed the problem by waiting for the sheet to be dismissed before prompting for the password.

For some reason, this bug only reproduces for me on my Touch Bar equipped MacBook Pro. Exporting signed profiles works just fine on my iMac, also running macOS Catalina.

Fixes #190.