### PR TITLE
Fix Font payloads not working for Microsoft OpenType

### DIFF
--- a/ProfileCreator/ProfileCreator/Utility/FontInfo.swift
+++ b/ProfileCreator/ProfileCreator/Utility/FontInfo.swift
@@ -25,8 +25,8 @@ struct FontInformation {
         }
     }
 
-    func descriptions(forLanguage language: FontTableName.LanguageID) -> [FontDescription] {
-        self.descriptions.filter { $0.language == language }
+    func descriptions(forLanguages language: [FontTableName.LanguageID]) -> [FontDescription] {
+        self.descriptions.filter { language.contains($0.language) }
     }
 
     func descriptions(forLanguage language: FontTableName.LanguageID, platform: FontTableName.PlatformIdentifier) -> [FontDescription] {
@@ -110,8 +110,13 @@ struct FontInformation {
             loc += MemoryLayout.size(ofValue: offset)
 
             // String
-            let encoding: String.Encoding
-            if platformIDRaw == 0 || 3 <= platformSpecificIDRaw {
+            var encoding: String.Encoding
+
+            // Use UTF-16 if
+            // Platform ID is Unicode OR Platform specific ID is Unicode 2.0 or above
+            // OR
+            // Platform ID is Microsoft AND Platform specific ID is Unicode
+            if (platformIDRaw == FontTableName.PlatformIdentifier.unicode.rawValue || FontTableName.PlatformSpecificID.Unicode.unicode2_0_bmp_only.rawValue <= platformSpecificIDRaw) || (platformIDRaw == FontTableName.PlatformIdentifier.microsoft.rawValue && platformSpecificIDRaw == FontTableName.PlatformSpecificID.Microsoft.unicodeBMP.rawValue) {
                 encoding = .utf16
             } else {
                 encoding = .utf8
@@ -472,6 +477,232 @@ enum FontTableName {
         case greek_polytonic = 148
         case greenlandic = 149
         case azerbaijani_roman_script = 150
+        
+        // Sticking the Microsoft Windows language IDs in here too since they are
+        // non-overlapping with the Macintosh language IDs
+        case ar_sa = 1025
+        case bg_bg = 1026
+        case ca_es = 1027
+        case zh_tw = 1028
+        case cs_cz = 1029
+        case da_dk = 1030
+        case de_de = 1031
+        case el_gr = 1032
+        case en_us = 1033
+        case es_es_tradnl = 1034
+        case fi_fi = 1035
+        case fr_fr = 1036
+        case he_il = 1037
+        case hu_hu = 1038
+        case is_is = 1039
+        case it_it = 1040
+        case ja_jp = 1041
+        case ko_kr = 1042
+        case nl_nl = 1043
+        case nb_no = 1044
+        case pl_pl = 1045
+        case pt_br = 1046
+        case rm_ch = 1047
+        case ro_ro = 1048
+        case ru_ru = 1049
+        case hr_hr = 1050
+        case sk_sk = 1051
+        case sq_al = 1052
+        case sv_se = 1053
+        case th_th = 1054
+        case tr_tr = 1055
+        case ur_pk = 1056
+        case id_id = 1057
+        case uk_ua = 1058
+        case be_by = 1059
+        case sl_si = 1060
+        case et_ee = 1061
+        case lv_lv = 1062
+        case lt_lt = 1063
+        case tg_cyrl_tj = 1064
+        case fa_ir = 1065
+        case vi_vn = 1066
+        case hy_am = 1067
+        case az_latn_az = 1068
+        case eu_es = 1069
+        case wen_de = 1070
+        case mk_mk = 1071
+        case st_za = 1072
+        case ts_za = 1073
+        case tn_za = 1074
+        case ven_za = 1075
+        case xh_za = 1076
+        case zu_za = 1077
+        case af_za = 1078
+        case ka_ge = 1079
+        case fo_fo = 1080
+        case hi_in = 1081
+        case mt_mt = 1082
+        case se_no = 1083
+        case gd_gb = 1084
+        case yi = 1085
+        case ms_my = 1086
+        case kk_kz = 1087
+        case ky_kg = 1088
+        case sw_ke = 1089
+        case tk_tm = 1090
+        case uz_latn_uz = 1091
+        case tt_ru = 1092
+        case bn_in = 1093
+        case pa_in = 1094
+        case gu_in = 1095
+        case or_in = 1096
+        case ta_in = 1097
+        case te_in = 1098
+        case kn_in = 1099
+        case ml_in = 1100
+        case as_in = 1101
+        case mr_in = 1102
+        case sa_in = 1103
+        case mn_mn = 1104
+        case bo_cn = 1105
+        case cy_gb = 1106
+        case km_kh = 1107
+        case lo_la = 1108
+        case my_mm = 1109
+        case gl_es = 1110
+        case kok_in = 1111
+        case mni = 1112
+        case sd_in = 1113
+        case syr_sy = 1114
+        case si_lk = 1115
+        case chr_us = 1116
+        case iu_cans_ca = 1117
+        case am_et = 1118
+        case tmz = 1119
+        case ks_arab_in = 1120
+        case ne_np = 1121
+        case fy_nl = 1122
+        case ps_af = 1123
+        case fil_ph = 1124
+        case dv_mv = 1125
+        case bin_ng = 1126
+        case fuv_ng = 1127
+        case ha_latn_ng = 1128
+        case ibb_ng = 1129
+        case yo_ng = 1130
+        case quz_bo = 1131
+        case nso_za = 1132
+        case ig_ng = 1136
+        case kr_ng = 1137
+        case gaz_et = 1138
+        case ti_er = 1139
+        case gn_py = 1140
+        case haw_us = 1141
+        case la = 1142
+        case so_so = 1143
+        case ii_cn = 1144
+        case pap_an = 1145
+        case ug_arab_cn = 1152
+        case mi_nz = 1153
+        case ar_iq = 2049
+        case zh_cn = 2052
+        case de_ch = 2055
+        case en_gb = 2057
+        case es_mx = 2058
+        case fr_be = 2060
+        case it_ch = 2064
+        case nl_be = 2067
+        case nn_no = 2068
+        case pt_pt = 2070
+        case ro_md = 2072
+        case ru_md = 2073
+        case sr_latn_cs = 2074
+        case sv_fi = 2077
+        case ur_in = 2080
+        case az_cyrl_az = 2092
+        case ga_ie = 2108
+        case ms_bn = 2110
+        case uz_cyrl_uz = 2115
+        case bn_bd = 2117
+        case pa_pk = 2118
+        case mn_mong_cn = 2128
+        case bo_bt = 2129
+        case sd_pk = 2137
+        case tzm_latn_dz = 2143
+        case ks_deva_in = 2144
+        case ne_in = 2145
+        case quz_ec = 2155
+        case ti_et = 2163
+        case ar_eg = 3073
+        case zh_hk = 3076
+        case de_at = 3079
+        case en_au = 3081
+        case es_es = 3082
+        case fr_ca = 3084
+        case sr_cyrl_cs = 3098
+        case quz_pe = 3179
+        case ar_ly = 4097
+        case zh_sg = 4100
+        case de_lu = 4103
+        case en_ca = 4105
+        case es_gt = 4106
+        case fr_ch = 4108
+        case hr_ba = 4122
+        case ar_dz = 5121
+        case zh_mo = 5124
+        case de_li = 5127
+        case en_nz = 5129
+        case es_cr = 5130
+        case fr_lu = 5132
+        case bs_latn_ba = 5146
+        case ar_mo = 6145
+        case en_ie = 6153
+        case es_pa = 6154
+        case fr_mc = 6156
+        case ar_tn = 7169
+        case en_za = 7177
+        case es_do = 7178
+        case fr_029 = 7180
+        case ar_om = 8193
+        case en_jm = 8201
+        case es_ve = 8202
+        case fr_re = 8204
+        case ar_ye = 9217
+        case en_029 = 9225
+        case es_co = 9226
+        case fr_cg = 9228
+        case ar_sy = 10241
+        case en_bz = 10249
+        case es_pe = 10250
+        case fr_sn = 10252
+        case ar_jo = 11265
+        case en_tt = 11273
+        case es_ar = 11274
+        case fr_cm = 11276
+        case ar_lb = 12289
+        case en_zw = 12297
+        case es_ec = 12298
+        case fr_ci = 12300
+        case ar_kw = 13313
+        case en_ph = 13321
+        case es_cl = 13322
+        case fr_ml = 13324
+        case ar_ae = 14337
+        case en_id = 14345
+        case es_uy = 14346
+        case fr_ma = 14348
+        case ar_bh = 15361
+        case en_hk = 15369
+        case es_py = 15370
+        case fr_ht = 15372
+        case ar_qa = 16385
+        case en_in = 16393
+        case es_bo = 16394
+        case en_my = 17417
+        case es_sv = 17418
+        case en_sg = 18441
+        case es_hn = 18442
+        case es_ni = 19466
+        case es_pr = 20490
+        case es_us = 21514
+        case es_419 = 58378
+        case fr_015 = 58380
     }
 
     enum NameID: UInt16 {

--- a/ProfileCreator/ProfileCreator/Utility/FontInfo.swift
+++ b/ProfileCreator/ProfileCreator/Utility/FontInfo.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreText
 
 struct FontInformation {
 
@@ -116,7 +117,8 @@ struct FontInformation {
             // Platform ID is Unicode OR Platform specific ID is Unicode 2.0 or above
             // OR
             // Platform ID is Microsoft AND Platform specific ID is Unicode
-            if (platformIDRaw == FontTableName.PlatformIdentifier.unicode.rawValue || FontTableName.PlatformSpecificID.Unicode.unicode2_0_bmp_only.rawValue <= platformSpecificIDRaw) || (platformIDRaw == FontTableName.PlatformIdentifier.microsoft.rawValue && platformSpecificIDRaw == FontTableName.PlatformSpecificID.Microsoft.unicodeBMP.rawValue) {
+            if (platformIDRaw == FontTableName.PlatformIdentifier.unicode.rawValue || FontTableName.PlatformSpecificID.Unicode.unicode2_0_bmp_only.rawValue <= platformSpecificIDRaw) ||
+                (platformIDRaw == FontTableName.PlatformIdentifier.microsoft.rawValue && platformSpecificIDRaw == FontTableName.PlatformSpecificID.Microsoft.unicodeBMP.rawValue) {
                 encoding = .utf16
             } else {
                 encoding = .utf8

--- a/ProfileCreator/ProfileCreator/Value Info Processors/ValueInfoProcessorFont.swift
+++ b/ProfileCreator/ProfileCreator/Value Info Processors/ValueInfoProcessorFont.swift
@@ -35,13 +35,16 @@ class ValueInfoProcessorFont: ValueInfoProcessor {
             return nil
         }
 
-        let fontDescriptions = fontInformation.descriptions(forLanguage: .english)
+        // Look for both language types to search across macintosh(.english), microsoft(.en_us) and unicode font descriptions.
+        let fontDescriptions = fontInformation.descriptions(forLanguages: [.english, .en_us])
 
         let fontDescription: FontDescription
         if let unicode = fontDescriptions.first(where: { $0.platformIdentifier == .unicode }) {
             fontDescription = unicode
         } else if let macintosh = fontDescriptions.first(where: { $0.platformIdentifier == .macintosh }) {
             fontDescription = macintosh
+        } else if let microsoft = fontDescriptions.first(where: {$0.platformIdentifier == .microsoft }) {
+            fontDescription = microsoft
         } else {
             return nil
         }


### PR DESCRIPTION
Add support for Font formats that contain Microsoft OpenType TrueType data. Reference https://github.com/ProfileCreator/ProfileCreator/issues/189

<img width="813" alt="Screenshot 2022-11-23 at 1 52 09 PM" src="https://user-images.githubusercontent.com/1198149/203653037-cd6398cc-4bf9-40de-9a6b-0366450742a6.png">
