### PR TITLE
Do not select combo box option during view init if already set by user

### DIFF
--- a/ProfileCreator/ProfileCreator/Profile Editor TableView CellViews/PayloadCellViewComboBox.swift
+++ b/ProfileCreator/ProfileCreator/Profile Editor TableView CellViews/PayloadCellViewComboBox.swift
@@ -82,14 +82,7 @@ class PayloadCellViewComboBox: PayloadCellView, ProfileCreatorCellView {
         // ---------------------------------------------------------------------
         //  Select Value
         // ---------------------------------------------------------------------
-        if
-            let selectedValue = value,
-            let title = PayloadUtility.title(forRangeListValue: selectedValue, subkey: subkey),
-            comboBox.objectValues.containsAny(value: title, ofType: .string) {
-            comboBox.selectItem(withObjectValue: title)
-        } else {
-            comboBox.objectValue = value
-        }
+        comboBox.objectValue = value
 
         // ---------------------------------------------------------------------
         //  Setup KeyView Loop Items

--- a/ProfileCreator/ProfileCreator/Profile Editor TableView CellViews/PayloadCellViewComboBox.swift
+++ b/ProfileCreator/ProfileCreator/Profile Editor TableView CellViews/PayloadCellViewComboBox.swift
@@ -71,18 +71,33 @@ class PayloadCellViewComboBox: PayloadCellView, ProfileCreatorCellView {
         //  Get Value
         // ---------------------------------------------------------------------
         let value: Any?
+        let isUserValue: Bool
         if let valueUser = self.profile.settings.value(forSubkey: subkey, payloadIndex: payloadIndex) {
             value = valueUser
+            isUserValue = true
         } else if let valueDefault = self.valueDefault {
             value = valueDefault
+            isUserValue = false
         } else {
             value = comboBox.objectValues.first
+            isUserValue = false
         }
 
         // ---------------------------------------------------------------------
         //  Select Value
         // ---------------------------------------------------------------------
-        comboBox.objectValue = value
+        if
+            let selectedValue = value,
+            let title = PayloadUtility.title(forRangeListValue: selectedValue, subkey: subkey),
+            comboBox.objectValues.containsAny(value: title, ofType: .string) {
+            if isUserValue {
+                comboBox.objectValue = title
+            } else {
+                comboBox.selectItem(withObjectValue: title)
+            }
+        } else {
+            comboBox.objectValue = value
+        }
 
         // ---------------------------------------------------------------------
         //  Setup KeyView Loop Items


### PR DESCRIPTION
A good example of where this needed is on `com.apple.extensiblesso`. Within the payload itself, there is a conditional target on `ExtensionIdentifier` which is a range list and due to the range list title logic, we end up selecting the combo box item and reloading the table forever because the table contains the combo box itself. In order to break this loop, we can utilize the fact that if a user has already set the value, we can just manually update the box with the title. This helps maintain the logic of displaying the right title while updating profile settings for actual user clicks.